### PR TITLE
Exclude options and futures in stock search

### DIFF
--- a/src/components/calculator/ui/HoldingsTable.tsx
+++ b/src/components/calculator/ui/HoldingsTable.tsx
@@ -155,7 +155,7 @@ export function HoldingsTable({
     await onAddAsset(newStockName.trim());
   };
 
-  const handleSearchSelect = (symbol: string, _companyName: string) => {
+  const handleSearchSelect = (symbol: string) => {
     onNewStockNameChange(symbol);
     // Auto-add when selected from search
     void onAddAsset(symbol);

--- a/src/components/calculator/ui/StockSearch.tsx
+++ b/src/components/calculator/ui/StockSearch.tsx
@@ -1,7 +1,7 @@
 import { useState, useEffect, useRef, useCallback } from 'react';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import { faSpinner, faSearch } from '@fortawesome/free-solid-svg-icons';
-import { isUSTicker, isPrimaryTicker, getBaseTicker } from './stockSearchUtils';
+import { isUSTicker, isPrimaryTicker, getBaseTicker, isOption, isFutures } from './stockSearchUtils';
 import styles from './StockSearch.module.css';
 
 interface StockSearchResult {
@@ -175,10 +175,22 @@ export function StockSearch({
       const data = await response.json();
 
       if (data.result && Array.isArray(data.result)) {
-        // Filter to only US stocks first
+        // Filter to only US stocks, excluding options and futures
         const usResults = data.result.filter((item: { symbol?: string; description?: string }) => {
           const symbol = item.symbol || '';
-          return symbol && isUSTicker(symbol);
+          const description = item.description || '';
+
+          // Must be a valid symbol
+          if (!symbol) return false;
+
+          // Exclude options (calls and puts)
+          if (isOption(symbol, description)) return false;
+
+          // Exclude futures contracts
+          if (isFutures(symbol, description)) return false;
+
+          // Must be US-based
+          return isUSTicker(symbol);
         });
 
         // Group results by base ticker

--- a/src/components/calculator/ui/__tests__/HoldingsTable.test.tsx
+++ b/src/components/calculator/ui/__tests__/HoldingsTable.test.tsx
@@ -3,8 +3,6 @@ import { render, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { HoldingsTable } from '../HoldingsTable';
 import type { CurrentPosition, Stock } from '../../types';
-import { server } from '../../../../test/server';
-import { http, HttpResponse } from 'msw';
 
 vi.mock('../../../../lib/useMediaQuery', () => ({
   useMediaQuery: vi.fn(() => false),
@@ -939,7 +937,6 @@ describe('HoldingsTable', () => {
     });
 
     it('should handle onSelect from StockSearch to auto-add asset', async () => {
-      const user = userEvent.setup();
       const onAddAsset = vi.fn().mockResolvedValue(undefined);
 
       render(

--- a/src/components/calculator/ui/__tests__/ResultsSection.test.tsx
+++ b/src/components/calculator/ui/__tests__/ResultsSection.test.tsx
@@ -514,7 +514,7 @@ describe('ResultsSection', () => {
 
     it('should handle allocations with null shares', () => {
       const allocations: AllocationResult[] = [
-        { name: 'AAPL', percentage: 50, amount: '500.00', shares: null as any },
+        { name: 'AAPL', percentage: 50, amount: '500.00', shares: null },
       ];
       render(<ResultsSection allocations={allocations} />);
 

--- a/src/components/calculator/ui/__tests__/StockList.test.tsx
+++ b/src/components/calculator/ui/__tests__/StockList.test.tsx
@@ -151,7 +151,8 @@ describe('StockList', () => {
 
   it('should call onAddStock when Add button is clicked', async () => {
     const user = userEvent.setup();
-    const onAddStock = vi.fn((symbol?: string, companyName?: string) => Promise.resolve());
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
+    const onAddStock = vi.fn((_symbol?: string, _companyName?: string) => Promise.resolve());
 
     render(<StockList {...defaultProps} newStockName="AAPL" onAddStock={onAddStock} />);
 
@@ -163,7 +164,8 @@ describe('StockList', () => {
 
   it('should call onAddStock when Enter is pressed in input', async () => {
     const user = userEvent.setup();
-    const onAddStock = vi.fn((symbol?: string, companyName?: string) => Promise.resolve());
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
+    const onAddStock = vi.fn((_symbol?: string, _companyName?: string) => Promise.resolve());
 
     render(<StockList {...defaultProps} newStockName="AAPL" onAddStock={onAddStock} />);
 
@@ -248,7 +250,8 @@ describe('StockList', () => {
 
   it('should not call onAddStock when input is empty and button is clicked', async () => {
     const user = userEvent.setup();
-    const onAddStock = vi.fn((symbol?: string, companyName?: string) => Promise.resolve());
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
+    const onAddStock = vi.fn((_symbol?: string, _companyName?: string) => Promise.resolve());
 
     render(<StockList {...defaultProps} newStockName="" onAddStock={onAddStock} />);
 
@@ -260,7 +263,8 @@ describe('StockList', () => {
 
   it('should not call onAddStock when input is only whitespace', async () => {
     const user = userEvent.setup();
-    const onAddStock = vi.fn((symbol?: string, companyName?: string) => Promise.resolve());
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
+    const onAddStock = vi.fn((_symbol?: string, _companyName?: string) => Promise.resolve());
 
     render(<StockList {...defaultProps} newStockName="   " onAddStock={onAddStock} />);
 

--- a/src/components/calculator/ui/__tests__/StockSearch.test.tsx
+++ b/src/components/calculator/ui/__tests__/StockSearch.test.tsx
@@ -145,7 +145,7 @@ describe('StockSearch', () => {
 
   it('should call onSelect with correct symbol and description when result is selected', () => {
     const onSelect = vi.fn();
-    const { container } = render(<StockSearch {...defaultProps} onSelect={onSelect} />);
+    render(<StockSearch {...defaultProps} onSelect={onSelect} />);
     
     // Manually trigger handleSelect by simulating internal state
     // We'll test this through the component's internal behavior

--- a/src/components/calculator/ui/__tests__/stockSearchUtils.test.ts
+++ b/src/components/calculator/ui/__tests__/stockSearchUtils.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { isUSTicker, isPrimaryTicker, getBaseTicker } from '../stockSearchUtils';
+import { isUSTicker, isPrimaryTicker, getBaseTicker, isOption, isFutures } from '../stockSearchUtils';
 
 describe('stockSearchUtils', () => {
   describe('isUSTicker', () => {
@@ -83,6 +83,101 @@ describe('stockSearchUtils', () => {
       expect(getBaseTicker('.TEST')).toBe('.TEST');
       // Empty string - dotIndex is -1, condition fails, returns original
       expect(getBaseTicker('')).toBe('');
+    });
+  });
+
+  describe('isOption', () => {
+    it('should return true for call options in description', () => {
+      expect(isOption('AAPL', 'Apple Inc. CALL Option')).toBe(true);
+      expect(isOption('MSFT', 'Microsoft CALL')).toBe(true);
+    });
+
+    it('should return true for put options in description', () => {
+      expect(isOption('AAPL', 'Apple Inc. PUT Option')).toBe(true);
+      expect(isOption('MSFT', 'Microsoft PUT')).toBe(true);
+    });
+
+    it('should return true for option keyword in description', () => {
+      expect(isOption('AAPL', 'Apple Inc. Option')).toBe(true);
+      expect(isOption('MSFT', 'Microsoft OPTION')).toBe(true);
+    });
+
+    it('should return true for option ticker patterns (YYMMDD + C/P + strike)', () => {
+      // Standard option format: TICKER + YYMMDD + C/P + STRIKE
+      expect(isOption('AAPL230120C00150000')).toBe(true); // Call option
+      expect(isOption('AAPL230120P00150000')).toBe(true); // Put option
+      expect(isOption('MSFT240315C00350000')).toBe(true); // Call option
+      expect(isOption('TSLA231215P00200000')).toBe(true); // Put option
+    });
+
+    it('should return false for regular stocks', () => {
+      expect(isOption('AAPL')).toBe(false);
+      expect(isOption('MSFT')).toBe(false);
+      expect(isOption('GOOGL')).toBe(false);
+    });
+
+    it('should return false for US share classes', () => {
+      expect(isOption('BRK.A')).toBe(false);
+      expect(isOption('BRK.B')).toBe(false);
+      expect(isOption('GOOGL.A')).toBe(false);
+    });
+
+    it('should handle case insensitivity', () => {
+      expect(isOption('aapl230120c00150000')).toBe(true);
+      expect(isOption('AAPL230120P00150000')).toBe(true);
+      expect(isOption('AAPL', 'call option')).toBe(true);
+      expect(isOption('AAPL', 'PUT OPTION')).toBe(true);
+    });
+
+    it('should return false for stocks with C or P in name but not option pattern', () => {
+      expect(isOption('AAPLC')).toBe(false); // Too short, not option pattern
+      expect(isOption('MSFTP')).toBe(false); // Too short, not option pattern
+    });
+  });
+
+  describe('isFutures', () => {
+    it('should return true for futures ending with =F', () => {
+      expect(isFutures('ES=F')).toBe(true); // E-mini S&P 500
+      expect(isFutures('NQ=F')).toBe(true); // E-mini Nasdaq
+      expect(isFutures('CL=F')).toBe(true); // Crude oil
+      expect(isFutures('GC=F')).toBe(true); // Gold
+      expect(isFutures('SI=F')).toBe(true); // Silver
+    });
+
+    it('should return true for futures in description', () => {
+      expect(isFutures('ES', 'E-mini S&P 500 FUTURE')).toBe(true);
+      expect(isFutures('NQ', 'Nasdaq FUTURES Contract')).toBe(true);
+      expect(isFutures('CL', 'Crude Oil FUTURE CONTRACT')).toBe(true);
+    });
+
+    it('should return true for common futures symbols', () => {
+      expect(isFutures('ESF')).toBe(true); // E-mini S&P 500 futures
+      expect(isFutures('NQF')).toBe(true); // E-mini Nasdaq futures
+      expect(isFutures('CLF')).toBe(true); // Crude oil futures
+      expect(isFutures('GCF')).toBe(true); // Gold futures
+    });
+
+    it('should return false for regular stocks', () => {
+      expect(isFutures('AAPL')).toBe(false);
+      expect(isFutures('MSFT')).toBe(false);
+      expect(isFutures('GOOGL')).toBe(false);
+    });
+
+    it('should return false for Frankfurt exchange (.F)', () => {
+      expect(isFutures('MSF.F')).toBe(false); // Frankfurt exchange, not futures
+      expect(isFutures('TEST.F')).toBe(false); // Frankfurt exchange, not futures
+    });
+
+    it('should handle case insensitivity', () => {
+      expect(isFutures('es=f')).toBe(true);
+      expect(isFutures('ES=F')).toBe(true);
+      expect(isFutures('ES', 'future contract')).toBe(true);
+      expect(isFutures('ES', 'FUTURES')).toBe(true);
+    });
+
+    it('should return false for stocks with F suffix that are not futures', () => {
+      expect(isFutures('AAPLF')).toBe(false); // Not a known futures symbol
+      expect(isFutures('MSFTF')).toBe(false); // Not a known futures symbol
     });
   });
 });

--- a/src/lib/__tests__/auth.test.tsx
+++ b/src/lib/__tests__/auth.test.tsx
@@ -52,7 +52,7 @@ function TestComponent() {
 
 describe('AuthProvider', () => {
   const alertSpy = vi.spyOn(window, 'alert').mockImplementation(() => {});
-  const consoleErrorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+  vi.spyOn(console, 'error').mockImplementation(() => {});
 
   beforeEach(() => {
     vi.clearAllMocks();


### PR DESCRIPTION
Add detection helpers and tests to filter out option and futures instruments from search results. Implements isOption and isFutures in stockSearchUtils (pattern/description checks, case-insensitive handling, special-casing common futures and avoiding .F Frankfurt symbols), updates StockSearch to use these helpers when filtering API results, and expands unit tests to cover various option and futures patterns and edge cases. Also updates imports accordingly.